### PR TITLE
mesonbuild/ogg: add libogg_dep

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -16,3 +16,6 @@ framing_test = executable('framing', 'framing.c',
 
 test('bitwise', bw_test)
 test('framing', framing_test)
+
+libogg_dep = declare_dependency(link_with : libogg,
+  include_directories : incdir)


### PR DESCRIPTION
Added a libogg_dep via declare_dependency in order to facilitate the use
of a fallback as mentioned in the [dependency](http://mesonbuild.com/Reference-manual.html#dependency) documentation.

Signed-off-by: Marty Plummer <ntzrmtthihu777@gmail.com>